### PR TITLE
Ensure correct connection ID usage

### DIFF
--- a/src/components/people/PersonConnectionManager.tsx
+++ b/src/components/people/PersonConnectionManager.tsx
@@ -151,7 +151,7 @@ export function PersonConnectionManager({ person, onConnectionUpdated }: PersonC
       const allConnections = uniqueConnections;
 
       setConnections(allConnections);
-      fetchExternalPersonNames(allConnections.map(c => c.id));
+      fetchExternalPersonNames(allConnections);
     } catch (error) {
       console.error('Error fetching connections:', error);
     } finally {
@@ -184,10 +184,10 @@ export function PersonConnectionManager({ person, onConnectionUpdated }: PersonC
     return externalPersonNames[personId] || 'Unknown';
   };
 
-  const fetchExternalPersonNames = async (connectionIds: string[]) => {
+  const fetchExternalPersonNames = async (connections: Connection[]) => {
     const externalPersonIds = new Set<string>();
     
-    // Collect all external person IDs
+    // Collect all external person IDs from the passed connections
     connections.forEach(conn => {
       if (!availablePersons.find(p => p.id === conn.from_person_id)) {
         externalPersonIds.add(conn.from_person_id);


### PR DESCRIPTION
Update `fetchExternalPersonNames` to accept connection objects directly, ensuring it uses fresh data instead of stale state.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-5bfbfdc7-16ce-4212-96d3-9f73eed5152b) · [Cursor](https://cursor.com/background-agent?bcId=bc-5bfbfdc7-16ce-4212-96d3-9f73eed5152b)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)