### PR TITLE
Redesign tree color system

### DIFF
--- a/src/components/family-trees/ConnectionManager.tsx
+++ b/src/components/family-trees/ConnectionManager.tsx
@@ -84,7 +84,7 @@ export function ConnectionManager({
     { value: "partner", label: "Partner", icon: Heart, color: "hsl(var(--chart-3))" },
     { value: "sibling", label: "Sibling", icon: Users, color: "hsl(var(--chart-4))" },
     { value: "donor", label: "Donor", icon: Dna, color: "hsl(var(--chart-5))" },
-    { value: "gestational_carrier", label: "Gestational Carrier", icon: Baby, color: "hsl(var(--chart-1))" },
+    { value: "gestational_carrier", label: "Gestational Carrier", icon: Baby, color: "hsl(var(--chart-6))" },
   ];
 
   const getPersonName = (personId: string) => {

--- a/src/components/family-trees/FamilyTreeVisualization.tsx
+++ b/src/components/family-trees/FamilyTreeVisualization.tsx
@@ -6,6 +6,7 @@ import { Plus, Users, Heart, Baby, Dna, GitBranch, Target, Zap, Network, Layers 
 import { AddPersonDialog } from "./AddPersonDialog";
 import { PersonCardDialog } from "@/components/people/PersonCard";
 import { ConnectionManager } from "./ConnectionManager";
+import { RelationshipLegend } from "./RelationshipLegend";
 
 import { TreeLayout } from "./layouts/TreeLayout";
 import { RadialTreeLayout } from "./layouts/RadialTreeLayout";
@@ -60,7 +61,7 @@ export function FamilyTreeVisualization({ familyTreeId, persons, onPersonAdded }
     { value: "partner", label: "Partner", icon: Heart, color: "hsl(var(--chart-3))" },
     { value: "sibling", label: "Sibling", icon: Users, color: "hsl(var(--chart-4))" },
     { value: "donor", label: "Donor", icon: Dna, color: "hsl(var(--chart-5))" },
-    { value: "gestational_carrier", label: "Gestational Carrier", icon: Baby, color: "hsl(var(--chart-1))" },
+    { value: "gestational_carrier", label: "Gestational Carrier", icon: Baby, color: "hsl(var(--chart-6))" },
   ];
 
   useEffect(() => {
@@ -212,7 +213,9 @@ export function FamilyTreeVisualization({ familyTreeId, persons, onPersonAdded }
           </div>
         </div>
       ) : (
-        <Tabs defaultValue="tree" className="w-full">
+        <div className="space-y-4">
+          <RelationshipLegend />
+          <Tabs defaultValue="tree" className="w-full">
           <TabsList className="grid w-full grid-cols-5">
             <TabsTrigger value="tree" className="flex items-center gap-1">
               <GitBranch className="w-3 h-3" />
@@ -291,6 +294,7 @@ export function FamilyTreeVisualization({ familyTreeId, persons, onPersonAdded }
             />
           </TabsContent>
         </Tabs>
+        </div>
       )}
 
       <AddPersonDialog

--- a/src/components/family-trees/PersonNode.tsx
+++ b/src/components/family-trees/PersonNode.tsx
@@ -24,6 +24,7 @@ interface PersonNodeProps {
   onDrop?: () => void;
   onPositionChange?: (position: { x: number; y: number }) => void;
   onClick?: () => void;
+  relationshipType?: string; // New prop for relationship-based coloring
 }
 
 const relationshipTypes = [
@@ -32,7 +33,7 @@ const relationshipTypes = [
   { value: "partner", label: "Partner", icon: Heart, color: "hsl(var(--chart-3))" },
   { value: "sibling", label: "Sibling", icon: Users, color: "hsl(var(--chart-4))" },
   { value: "donor", label: "Donor", icon: Dna, color: "hsl(var(--chart-5))" },
-  { value: "gestational_carrier", label: "Gestational Carrier", icon: Baby, color: "hsl(var(--chart-1))" },
+  { value: "gestational_carrier", label: "Gestational Carrier", icon: Baby, color: "hsl(var(--chart-6))" },
 ];
 
 export const PersonNode = memo(({
@@ -48,11 +49,22 @@ export const PersonNode = memo(({
   onDrop,
   onPositionChange,
   onClick,
+  relationshipType,
 }: PersonNodeProps) => {
   const [isDragging, setIsDragging] = useState(false);
   const [dragOffset, setDragOffset] = useState({ x: 0, y: 0 });
-  const getNodeColor = (gender?: string | null) => {
-    switch (gender?.toLowerCase()) {
+  
+  const getNodeColor = () => {
+    // If relationship type is provided, use relationship-based coloring
+    if (relationshipType) {
+      const relationship = relationshipTypes.find(rt => rt.value === relationshipType);
+      if (relationship) {
+        return relationship.color;
+      }
+    }
+    
+    // Fallback to gender-based coloring for backward compatibility
+    switch (person.gender?.toLowerCase()) {
       case 'male': return "hsl(var(--chart-1))";
       case 'female': return "hsl(var(--chart-2))";
       default: return "hsl(var(--chart-3))";
@@ -117,7 +129,7 @@ export const PersonNode = memo(({
         className={`relative w-20 h-20 rounded-full border-2 transition-all ${
           isDragged ? 'border-primary border-4' : 'border-border'
         } ${isHovered && isConnecting ? 'border-primary border-4 animate-pulse' : ''}`}
-        style={{ backgroundColor: getNodeColor(person.gender) }}
+        style={{ backgroundColor: getNodeColor() }}
         draggable={isConnecting}
         onDragStart={isConnecting ? (e) => {
           e.dataTransfer.effectAllowed = 'move';

--- a/src/components/family-trees/PublicFamilyTreeViewer.tsx
+++ b/src/components/family-trees/PublicFamilyTreeViewer.tsx
@@ -79,7 +79,7 @@ export function PublicFamilyTreeViewer({
     { value: "partner", label: "Partner", color: "hsl(var(--chart-3))" },
     { value: "sibling", label: "Sibling", color: "hsl(var(--chart-4))" },
     { value: "donor", label: "Donor", color: "hsl(var(--chart-5))" },
-    { value: "gestational_carrier", label: "Gestational Carrier", color: "hsl(var(--chart-1))" },
+    { value: "gestational_carrier", label: "Gestational Carrier", color: "hsl(var(--chart-6))" },
   ];
 
   useEffect(() => {

--- a/src/components/family-trees/RelationshipDialog.tsx
+++ b/src/components/family-trees/RelationshipDialog.tsx
@@ -25,7 +25,7 @@ const relationshipTypes = [
   { value: "partner", label: "Partner/Spouse", icon: Heart, color: "hsl(var(--chart-3))", description: "Romantic partnership or marriage" },
   { value: "sibling", label: "Sibling", icon: Users, color: "hsl(var(--chart-4))", description: "Sibling relationship (full, half, step, etc.)" },
   { value: "donor", label: "Donor", icon: Dna, color: "hsl(var(--chart-5))", description: "Genetic donor (sperm, egg, embryo)" },
-  { value: "gestational_carrier", label: "Gestational Carrier", icon: Baby, color: "hsl(var(--chart-1))", description: "Surrogate or gestational carrier" },
+      { value: "gestational_carrier", label: "Gestational Carrier", icon: Baby, color: "hsl(var(--chart-6))", description: "Surrogate or gestational carrier" },
 ];
 
 export function RelationshipDialog({

--- a/src/components/family-trees/RelationshipLegend.tsx
+++ b/src/components/family-trees/RelationshipLegend.tsx
@@ -1,0 +1,101 @@
+import { Users, Heart, Baby, Dna } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+
+interface RelationshipType {
+  value: string;
+  label: string;
+  icon: any;
+  color: string;
+  description: string;
+}
+
+const relationshipTypes: RelationshipType[] = [
+  { 
+    value: "parent", 
+    label: "Parent", 
+    icon: Users, 
+    color: "hsl(var(--chart-1))",
+    description: "Biological or adoptive parent"
+  },
+  { 
+    value: "child", 
+    label: "Child", 
+    icon: Baby, 
+    color: "hsl(var(--chart-2))",
+    description: "Biological or adopted child"
+  },
+  { 
+    value: "partner", 
+    label: "Partner", 
+    icon: Heart, 
+    color: "hsl(var(--chart-3))",
+    description: "Spouse or romantic partner"
+  },
+  { 
+    value: "sibling", 
+    label: "Sibling", 
+    icon: Users, 
+    color: "hsl(var(--chart-4))",
+    description: "Brother or sister"
+  },
+  { 
+    value: "donor", 
+    label: "Donor", 
+    icon: Dna, 
+    color: "hsl(var(--chart-5))",
+    description: "Genetic donor (sperm, egg, embryo)"
+  },
+  { 
+    value: "gestational_carrier", 
+    label: "Gestational Carrier", 
+    icon: Baby, 
+    color: "hsl(var(--chart-6))",
+    description: "Surrogate or gestational carrier"
+  },
+];
+
+interface RelationshipLegendProps {
+  className?: string;
+}
+
+export function RelationshipLegend({ className = "" }: RelationshipLegendProps) {
+  return (
+    <div className={`bg-card border rounded-lg p-4 ${className}`}>
+      <h3 className="text-sm font-semibold mb-3 text-foreground">Relationship Types</h3>
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+        {relationshipTypes.map((type) => {
+          const Icon = type.icon;
+          return (
+            <div
+              key={type.value}
+              className="flex items-center gap-2 p-2 rounded-md bg-muted/50 hover:bg-muted transition-colors"
+            >
+              <div
+                className="w-4 h-4 rounded-full flex items-center justify-center"
+                style={{ backgroundColor: type.color }}
+              >
+                <Icon className="w-2.5 h-2.5 text-white" />
+              </div>
+              <div className="flex-1 min-w-0">
+                <div className="text-sm font-medium text-foreground truncate">
+                  {type.label}
+                </div>
+                <div className="text-xs text-muted-foreground truncate">
+                  {type.description}
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+      <div className="mt-3 pt-3 border-t">
+        <p className="text-xs text-muted-foreground">
+          <strong>Node colors:</strong> Represent the person's primary relationship type
+        </p>
+        <p className="text-xs text-muted-foreground">
+          <strong>Connection lines:</strong> Show the relationship type between connected people
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/family-trees/layouts/ClusterLayout.tsx
+++ b/src/components/family-trees/layouts/ClusterLayout.tsx
@@ -6,6 +6,7 @@ interface Person {
   name: string;
   gender?: string | null;
   profile_photo_url?: string | null;
+  donor?: boolean;
 }
 
 interface Connection {
@@ -74,8 +75,8 @@ export function ClusterLayout({ persons, connections, relationshipTypes, width, 
         .x(d => d.x!)
         .y(d => d.y!))
       .attr('fill', 'none')
-      .attr('stroke', 'hsl(var(--border))')
-      .attr('stroke-width', 2);
+      .attr('stroke', d => getConnectionColor(d.source.data, d.target.data, validConnections, relationshipTypes))
+      .attr('stroke-width', 3);
 
     // Create nodes
     const nodes = g.selectAll('.node')
@@ -231,6 +232,25 @@ function getPersonColor(person: Person, connections: Connection[], relationshipT
     }
   }
   
-  // Default to first relationship type color if no specific relationship found
-  return relationshipTypes[0]?.color || 'hsl(var(--chart-1))';
+  // If no relationship found, check if person is a donor
+  if (person.donor) {
+    const donorType = relationshipTypes.find(rt => rt.value === 'donor');
+    if (donorType) {
+      return donorType.color;
+    }
+  }
+  
+  // Default to parent color if no specific relationship found
+  return 'hsl(var(--chart-1))';
+}
+
+function getConnectionColor(source: Person, target: Person, connections: Connection[], relationshipTypes: RelationshipType[]): string {
+  const connection = connections.find(c => c.from_person_id === source.id && c.to_person_id === target.id);
+  if (connection) {
+    const relationshipType = relationshipTypes.find(rt => rt.value === connection.relationship_type);
+    if (relationshipType) {
+      return relationshipType.color;
+    }
+  }
+  return 'hsl(var(--border))'; // Default color for unconnected nodes
 }

--- a/src/components/family-trees/layouts/ForceDirectedLayout.tsx
+++ b/src/components/family-trees/layouts/ForceDirectedLayout.tsx
@@ -6,6 +6,7 @@ interface Person {
   name: string;
   gender?: string | null;
   profile_photo_url?: string | null;
+  donor?: boolean;
 }
 
 interface Connection {
@@ -198,8 +199,16 @@ function getPersonColor(person: Person, connections: Connection[], relationshipT
     }
   }
   
-  // Default to first relationship type color if no specific relationship found
-  return relationshipTypes[0]?.color || 'hsl(var(--chart-1))';
+  // If no relationship found, check if person is a donor
+  if (person.donor) {
+    const donorType = relationshipTypes.find(rt => rt.value === 'donor');
+    if (donorType) {
+      return donorType.color;
+    }
+  }
+  
+  // Default to parent color if no specific relationship found
+  return 'hsl(var(--chart-1))';
 }
 
 function getRelationshipColor(relationship: string, relationshipTypes: RelationshipType[]): string {

--- a/src/components/family-trees/layouts/RadialTreeLayout.tsx
+++ b/src/components/family-trees/layouts/RadialTreeLayout.tsx
@@ -6,6 +6,7 @@ interface Person {
   name: string;
   gender?: string | null;
   profile_photo_url?: string | null;
+  donor?: boolean;
 }
 
 interface Connection {
@@ -77,8 +78,8 @@ export function RadialTreeLayout({ persons, connections, relationshipTypes, widt
         .angle(d => d.x!)
         .radius(d => d.y!))
       .attr('fill', 'none')
-      .attr('stroke', 'hsl(var(--border))')
-      .attr('stroke-width', 2);
+      .attr('stroke', d => getConnectionColor(d.source.data, d.target.data, validConnections, relationshipTypes))
+      .attr('stroke-width', 3);
 
     // Create nodes
     const nodes = g.selectAll('.node')
@@ -216,6 +217,25 @@ function getPersonColor(person: Person, connections: Connection[], relationshipT
     }
   }
   
-  // Default to first relationship type color if no specific relationship found
-  return relationshipTypes[0]?.color || 'hsl(var(--chart-1))';
+  // If no relationship found, check if person is a donor
+  if (person.donor) {
+    const donorType = relationshipTypes.find(rt => rt.value === 'donor');
+    if (donorType) {
+      return donorType.color;
+    }
+  }
+  
+  // Default to parent color if no specific relationship found
+  return 'hsl(var(--chart-1))';
+}
+
+function getConnectionColor(source: Person, target: Person, connections: Connection[], relationshipTypes: RelationshipType[]): string {
+  const connection = connections.find(c => c.from_person_id === source.id && c.to_person_id === target.id);
+  if (connection) {
+    const relationshipType = relationshipTypes.find(rt => rt.value === connection.relationship_type);
+    if (relationshipType) {
+      return relationshipType.color;
+    }
+  }
+  return 'hsl(var(--border))'; // Default color for unconnected nodes
 }

--- a/src/components/family-trees/layouts/TreeLayout.tsx
+++ b/src/components/family-trees/layouts/TreeLayout.tsx
@@ -6,6 +6,7 @@ interface Person {
   name: string;
   gender?: string | null;
   profile_photo_url?: string | null;
+  donor?: boolean;
 }
 
 interface Connection {
@@ -74,8 +75,8 @@ export function TreeLayout({ persons, connections, relationshipTypes, width, hei
         .x(d => d.x!)
         .y(d => d.y!))
       .attr('fill', 'none')
-      .attr('stroke', 'hsl(var(--border))')
-      .attr('stroke-width', 2);
+      .attr('stroke', d => getConnectionColor(d.source.data, d.target.data, validConnections, relationshipTypes))
+      .attr('stroke-width', 3);
 
     // Create nodes
     const nodes = g.selectAll('.node')
@@ -203,6 +204,25 @@ function getPersonColor(person: Person, connections: Connection[], relationshipT
     }
   }
   
-  // Default to first relationship type color if no specific relationship found
-  return relationshipTypes[0]?.color || 'hsl(var(--chart-1))';
+  // If no relationship found, check if person is a donor
+  if (person.donor) {
+    const donorType = relationshipTypes.find(rt => rt.value === 'donor');
+    if (donorType) {
+      return donorType.color;
+    }
+  }
+  
+  // Default to parent color if no specific relationship found
+  return 'hsl(var(--chart-1))';
+}
+
+function getConnectionColor(source: Person, target: Person, connections: Connection[], relationshipTypes: RelationshipType[]): string {
+  const connection = connections.find(c => c.from_person_id === source.id && c.to_person_id === target.id);
+  if (connection) {
+    const relationshipType = relationshipTypes.find(rt => rt.value === connection.relationship_type);
+    if (relationshipType) {
+      return relationshipType.color;
+    }
+  }
+  return 'hsl(var(--border))'; // Default color for unconnected nodes
 }

--- a/src/components/people/PersonConnectionManager.tsx
+++ b/src/components/people/PersonConnectionManager.tsx
@@ -82,7 +82,7 @@ export function PersonConnectionManager({ person, onConnectionUpdated }: PersonC
     { value: "partner", label: "Partner", icon: Heart, color: "hsl(var(--chart-3))" },
     { value: "sibling", label: "Sibling", icon: Users, color: "hsl(var(--chart-4))" },
     { value: "donor", label: "Donor", icon: Dna, color: "hsl(var(--chart-5))" },
-    { value: "gestational_carrier", label: "Gestational Carrier", icon: Baby, color: "hsl(var(--chart-1))" },
+    { value: "gestational_carrier", label: "Gestational Carrier", icon: Baby, color: "hsl(var(--chart-6))" },
   ];
 
   useEffect(() => {

--- a/src/index.css
+++ b/src/index.css
@@ -38,11 +38,12 @@
     --radius: 0.75rem;
 
     /* Chart colors for data visualization */
-    --chart-1: 220 70% 50%;
-    --chart-2: 340 75% 55%;
-    --chart-3: 45 93% 47%;
-    --chart-4: 280 65% 60%;
-    --chart-5: 160 60% 45%;
+    --chart-1: 220 70% 50%;  /* Blue - Parent */
+    --chart-2: 340 75% 55%;  /* Pink - Child */
+    --chart-3: 45 93% 47%;   /* Yellow - Partner */
+    --chart-4: 280 65% 60%;  /* Purple - Sibling */
+    --chart-5: 160 60% 45%;  /* Green - Donor */
+    --chart-6: 200 70% 50%;  /* Cyan - Gestational Carrier */
 
     --sidebar-background: 32 25% 98%;
     --sidebar-foreground: 32 15% 20%;
@@ -84,11 +85,12 @@
     --ring: 32 25% 75%;
 
     /* Chart colors for data visualization (dark mode) */
-    --chart-1: 220 70% 60%;
-    --chart-2: 340 75% 65%;
-    --chart-3: 45 93% 57%;
-    --chart-4: 280 65% 70%;
-    --chart-5: 160 60% 55%;
+    --chart-1: 220 70% 60%;  /* Blue - Parent */
+    --chart-2: 340 75% 65%;  /* Pink - Child */
+    --chart-3: 45 93% 57%;   /* Yellow - Partner */
+    --chart-4: 280 65% 70%;  /* Purple - Sibling */
+    --chart-5: 160 60% 55%;  /* Green - Donor */
+    --chart-6: 200 70% 60%;  /* Cyan - Gestational Carrier */
     
     --sidebar-background: 32 25% 8%;
     --sidebar-foreground: 32 25% 90%;


### PR DESCRIPTION
Redesign family tree color-coding system for clarity and consistency, ensuring relationship-based coloring and a clear legend.

Previously, node colors were inconsistently applied (mixing gender-based and relationship-based logic), leading to confusion (e.g., donors appearing blue). This PR standardizes node and edge coloring based on relationship types, introduces a dedicated green color for donors, and adds a comprehensive legend to improve visual clarity and user understanding of the family tree.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-1346846e-dd00-4605-8f51-2cd3c110d5b1) · [Cursor](https://cursor.com/background-agent?bcId=bc-1346846e-dd00-4605-8f51-2cd3c110d5b1)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)