### PR TITLE
Safely handle error messages

### DIFF
--- a/src/components/family-trees/PublicFamilyTreeViewer.tsx
+++ b/src/components/family-trees/PublicFamilyTreeViewer.tsx
@@ -143,7 +143,7 @@ export function PublicFamilyTreeViewer({
       console.error('Access check failed:', error);
       toast({
         title: "Access Denied",
-        description: error.message || "You don't have permission to view this family tree",
+        description: (error instanceof Error ? error.message : String(error)) || "You don't have permission to view this family tree",
         variant: "destructive",
       });
       setHasAccess(false);

--- a/src/components/family-trees/SharingSettingsDialog.tsx
+++ b/src/components/family-trees/SharingSettingsDialog.tsx
@@ -219,7 +219,7 @@ export function SharingSettingsDialog({
       });
 
       if (error) {
-        throw new Error(error.message || 'Failed to send invitations');
+        throw new Error((error instanceof Error ? error.message : String(error)) || 'Failed to send invitations');
       }
       
       if (result?.failed > 0) {

--- a/src/components/family-trees/XYFlowTreeBuilder.tsx
+++ b/src/components/family-trees/XYFlowTreeBuilder.tsx
@@ -151,7 +151,7 @@ export function XYFlowTreeBuilder({ familyTreeId, persons, onPersonAdded }: XYFl
             console.error('Layout application error:', error);
             toast({
               title: "Layout Error",
-              description: error.message === 'Layout timeout' 
+              description: (error instanceof Error && error.message === 'Layout timeout') 
                 ? "Layout took too long. Try a different layout or fewer nodes."
                 : "Failed to apply layout. Please try again.",
               variant: "destructive",

--- a/src/components/family-trees/layouts/XYFlowLayoutService.ts
+++ b/src/components/family-trees/layouts/XYFlowLayoutService.ts
@@ -145,7 +145,7 @@ export class XYFlowLayoutService {
 
       return { nodes: updatedNodes, edges };
     } catch (error) {
-      console.error('ELK layout error:', error);
+      console.error('ELK layout error:', error instanceof Error ? error.message : String(error));
       return { nodes, edges };
     }
   }


### PR DESCRIPTION
Safely access `error.message` to prevent runtime errors and ensure accurate user feedback.

JavaScript's `catch` blocks can receive non-Error objects or primitives, leading to `undefined` or runtime errors when `error.message` is directly accessed. This PR ensures errors are handled gracefully, providing consistent user messages.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-6f786ac0-1bf9-4397-98f7-938b58cd5827) · [Cursor](https://cursor.com/background-agent?bcId=bc-6f786ac0-1bf9-4397-98f7-938b58cd5827)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)