### PR TITLE
Fix terser config and console warnings

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -34,10 +34,11 @@ export default defineConfig(({ mode }) => ({
     },
     // Enable tree shaking
     minify: 'terser',
-    terserOptions: {
-      compress: {
-        drop_console: mode === 'production',
-        drop_debugger: mode === 'production',
+    terser: {
+      terserOptions: {
+        compress: {
+          drop_debugger: mode === 'production',
+        },
       },
     },
     // Optimize chunk size


### PR DESCRIPTION
Correct `terserOptions` nesting in Vite config and remove `drop_console` to allow performance monitoring warnings in production.

The `drop_console` setting was preventing `console.warn()` statements from the new performance monitoring system from appearing in production builds, which was unintended and defeated its purpose.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-fb02eecc-fe86-49fc-872d-0676e7062bcd) · [Cursor](https://cursor.com/background-agent?bcId=bc-fb02eecc-fe86-49fc-872d-0676e7062bcd)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)