### PR TITLE
Correct vite terser options nesting

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -34,11 +34,9 @@ export default defineConfig(({ mode }) => ({
     },
     // Enable tree shaking
     minify: 'terser',
-    terser: {
-      terserOptions: {
-        compress: {
-          drop_debugger: mode === 'production',
-        },
+    terserOptions: {
+      compress: {
+        drop_debugger: mode === 'production',
       },
     },
     // Optimize chunk size


### PR DESCRIPTION
Correct `terserOptions` nesting in `vite.config.ts` to ensure `drop_debugger` is applied in production builds.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-b59a8411-74ed-4009-80c4-c099fc89db2f) · [Cursor](https://cursor.com/background-agent?bcId=bc-b59a8411-74ed-4009-80c4-c099fc89db2f)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)