### PR TITLE
Add missing props to XYFlowTreeBuilder

### DIFF
--- a/src/components/family-trees/FamilyTreeVisualization.tsx
+++ b/src/components/family-trees/FamilyTreeVisualization.tsx
@@ -268,6 +268,9 @@ export function FamilyTreeVisualization({ familyTreeId, persons, onPersonAdded }
               familyTreeId={familyTreeId}
               persons={persons}
               connections={connections}
+              relationshipTypes={relationshipTypes}
+              width={dimensions.width}
+              height={dimensions.height}
               onPersonClick={handlePersonClick}
             />
           </Suspense>


### PR DESCRIPTION
Add `relationshipTypes`, `width`, and `height` props to `XYFlowTreeBuilder` to align with other layout components and resolve potential rendering issues.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-53246df1-aa1a-4442-95b4-2b7245a005aa) · [Cursor](https://cursor.com/background-agent?bcId=bc-53246df1-aa1a-4442-95b4-2b7245a005aa)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)