### PR TITLE
Fix connection manager prop mismatch

### DIFF
--- a/src/components/family-trees/FamilyTreeVisualization.tsx
+++ b/src/components/family-trees/FamilyTreeVisualization.tsx
@@ -130,8 +130,7 @@ export function FamilyTreeVisualization({ familyTreeId, persons, onPersonAdded }
           <ConnectionManager 
             familyTreeId={familyTreeId}
             persons={persons}
-            connections={connections}
-            onConnectionsUpdated={fetchConnections}
+            onConnectionUpdated={fetchConnections}
           />
         </div>
       </div>


### PR DESCRIPTION
Fix `ConnectionManager` prop mismatch in `FamilyTreeVisualization` to enable connection data refresh.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-ea147e04-6cf8-47d4-aee4-30b217fd5326) · [Cursor](https://cursor.com/background-agent?bcId=bc-ea147e04-6cf8-47d4-aee4-30b217fd5326)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)