### PR TITLE
Fix service worker and preload paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,6 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     
     <!-- Preload critical resources -->
-    <link rel="preload" href="/src/main.tsx" as="script" type="module">
     <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap" as="style">
     
     <!-- Mobile optimization -->

--- a/public/sw.js
+++ b/public/sw.js
@@ -6,8 +6,6 @@ const DYNAMIC_CACHE = 'dynamic-v1';
 const STATIC_FILES = [
   '/',
   '/index.html',
-  '/src/main.tsx',
-  '/src/index.css',
 ];
 
 // Install event - cache static files


### PR DESCRIPTION
Remove incorrect preload hint and service worker cache entries for source files to fix production build errors.

The `index.html` preload hint and the service worker's static cache list in `public/sw.js` both incorrectly referenced `/src/main.tsx` (and `/src/index.css` for the service worker). In production, Vite bundles and renames these files (e.g., to `/assets/main-[hash].js`), causing the original paths to not exist. This led to the preload hint failing (potentially regressing performance) and the service worker's `cache.addAll()` failing with a 404 error during installation.

---

[Open in Web](https://www.cursor.com/agents?id=bc-472fae50-3bf8-4ed1-82c8-bfcd1e82092d) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-472fae50-3bf8-4ed1-82c8-bfcd1e82092d)