### PR TITLE
Fix broken invitation link

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -65,6 +65,7 @@ const App = () => (
               <Route path="/public/tree/:id" element={<PublicFamilyTree />} />
               <Route path="/shared/tree/:id" element={<PublicFamilyTree />} />
               <Route path="/invite/:action/:token" element={<OrganizationInvitePage />} />
+              <Route path="/invite/:action/P/:token" element={<OrganizationInvitePage />} />
               <Route path="/invitation/:action/:token" element={<InvitationPage />} />
               
               {/* Admin routes */}

--- a/src/pages/OrganizationInvitePage.tsx
+++ b/src/pages/OrganizationInvitePage.tsx
@@ -50,19 +50,22 @@ export default function OrganizationInvitePage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  // Decode the token to handle URL encoding issues
+  const decodedToken = token ? decodeURIComponent(token) : null;
+
   useEffect(() => {
     fetchInvitationDetails();
-  }, [token]);
+  }, [decodedToken]);
 
   // If user is already authenticated, redirect to the normal invitation flow
   useEffect(() => {
     if (!authLoading && user && invitation && !error) {
-      navigate(`/invitation/${action}/${token}`);
+      navigate(`/invitation/${action}/${decodedToken}`);
     }
-  }, [authLoading, user, invitation, error, action, token, navigate]);
+  }, [authLoading, user, invitation, error, action, decodedToken, navigate]);
 
   const fetchInvitationDetails = async () => {
-    if (!token) {
+    if (!decodedToken) {
       setError("Invalid invitation link");
       setLoading(false);
       return;
@@ -88,7 +91,7 @@ export default function OrganizationInvitePage() {
             subdomain
           )
         `)
-        .eq('token', token)
+        .eq('token', decodedToken)
         .single();
 
       if (invitationError || !invitationData) {

--- a/supabase/functions/process-invitation/index.ts
+++ b/supabase/functions/process-invitation/index.ts
@@ -30,6 +30,9 @@ serve(async (req) => {
       throw new Error("Missing required parameters");
     }
 
+    // Decode the token to handle URL encoding issues
+    const decodedToken = decodeURIComponent(token);
+
     // Create Supabase client
     const supabase = await createClient();
 
@@ -37,7 +40,7 @@ serve(async (req) => {
     const { data: invitation, error: invitationError } = await supabase
       .from("organization_invitations")
       .select("*, organizations(*)")
-      .eq("token", token)
+      .eq("token", decodedToken)
       .single();
 
     if (invitationError || !invitation) {

--- a/supabase/functions/send-invitation/index.ts
+++ b/supabase/functions/send-invitation/index.ts
@@ -56,8 +56,8 @@ serve(async (req) => {
     const role = invitation.role;
     
     // Generate accept/decline links
-    const acceptUrl = `${appUrl}/invite/accept/${invitation.token}`;
-    const declineUrl = `${appUrl}/invite/decline/${invitation.token}`;
+    const acceptUrl = `${appUrl}/invite/accept/${encodeURIComponent(invitation.token)}`;
+    const declineUrl = `${appUrl}/invite/decline/${encodeURIComponent(invitation.token)}`;
 
     // Send the invitation email
     console.log("Attempting to send email to:", inviteeEmail);


### PR DESCRIPTION
Fix 404 error on organization invite links by handling URL encoding/decoding and malformed paths.

The issue stemmed from inconsistent URL encoding/decoding of invitation tokens (especially those with special characters like '+') across the frontend and backend, leading to invalid tokens being processed. Additionally, some generated invite URLs contained an unexpected `/P/` segment, causing routing failures.

---

[Open in Web](https://www.cursor.com/agents?id=bc-1012041d-ec71-4ead-b66a-98a815c2c4fa) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-1012041d-ec71-4ead-b66a-98a815c2c4fa)