### PR TITLE
Fix getInitials for multiple spaces

### DIFF
--- a/src/components/organizations/DonorDetailsDialog.tsx
+++ b/src/components/organizations/DonorDetailsDialog.tsx
@@ -149,7 +149,7 @@ export function DonorDetailsDialog({
   };
 
   const getInitials = (name: string) => {
-    return name.split(' ').map(n => n[0]).join('').toUpperCase().slice(0, 2);
+    return name.split(' ').filter(n => n.length > 0).map(n => n[0]).join('').toUpperCase().slice(0, 2);
   };
 
   if (!donor) return null;


### PR DESCRIPTION
Fix `getInitials` function to correctly handle names with multiple consecutive spaces.

The previous implementation would produce `undefined` in the initials (e.g., 'JundefinedS') because `split(' ')` created empty strings for consecutive spaces, and accessing `n[0]` on an empty string returns `undefined`.

---

[Open in Web](https://www.cursor.com/agents?id=bc-2497191a-b2e7-4075-a514-ca05de29ec58) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-2497191a-b2e7-4075-a514-ca05de29ec58)