### PR TITLE
Fix inconsistent user id column names

### DIFF
--- a/src/components/SignedInHome.tsx
+++ b/src/components/SignedInHome.tsx
@@ -72,17 +72,32 @@ const SignedInHome = () => {
       }
 
       // Fetch quick stats
-      const [familyTreesData, peopleData, organizationsData, mediaData] = await Promise.all([
+      const [familyTreesData, peopleData, mediaData] = await Promise.all([
         supabase.from('family_trees').select('id', { count: 'exact' }).eq('user_id', user!.id),
         supabase.from('people').select('id', { count: 'exact' }).eq('user_id', user!.id),
-        supabase.from('organizations').select('id', { count: 'exact' }).eq('owner_id', user!.id),
         supabase.from('media_items').select('id', { count: 'exact' }).eq('user_id', user!.id)
+      ]);
+
+      // Fetch organizations count (both owned and member organizations)
+      const [ownedOrgsData, memberOrgsData] = await Promise.all([
+        supabase.from('organizations').select('id', { count: 'exact' }).eq('owner_id', user!.id),
+        supabase.from('organization_memberships').select('organization_id', { count: 'exact' }).eq('user_id', user!.id)
+      ]);
+
+      // Get unique organization count (owned + member organizations, avoiding duplicates)
+      const ownedOrgs = ownedOrgsData.data || [];
+      const memberOrgs = memberOrgsData.data || [];
+      
+      // Create a set of unique organization IDs
+      const uniqueOrgIds = new Set([
+        ...ownedOrgs.map(org => org.id),
+        ...memberOrgs.map(member => member.organization_id)
       ]);
 
       setStats({
         familyTrees: familyTreesData.count || 0,
         people: peopleData.count || 0,
-        organizations: organizationsData.count || 0,
+        organizations: uniqueOrgIds.size,
         mediaItems: mediaData.count || 0
       });
 


### PR DESCRIPTION
Update organization count in SignedInHome to include both owned and member organizations.

The initial bug report incorrectly identified a schema inconsistency. The actual issue was that the `SignedInHome` component only counted organizations where the user was the `owner`, leading to an incomplete count. This PR now fetches both owned organizations and organizations where the user is a member, then deduplicates them to provide an accurate total, consistent with other parts of the application.

---

[Open in Web](https://www.cursor.com/agents?id=bc-ad29bf6b-1675-4f59-91f7-14a62a913b70) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-ad29bf6b-1675-4f59-91f7-14a62a913b70)