### PR TITLE
Deduplicate siblings in getSiblings function

### DIFF
--- a/src/utils/relationshipHierarchies.ts
+++ b/src/utils/relationshipHierarchies.ts
@@ -96,14 +96,18 @@ export function getChildren(personId: string, hierarchy: RelationshipHierarchy):
  */
 export function getSiblings(personId: string, hierarchy: RelationshipHierarchy): Person[] {
   const parents = getParents(personId, hierarchy);
-  const siblings: Person[] = [];
+  const siblingIds = new Set<string>();
   
   parents.forEach(parent => {
     const parentChildren = getChildren(parent.id, hierarchy);
-    siblings.push(...parentChildren.filter(child => child.id !== personId));
+    parentChildren.forEach(child => {
+      if (child.id !== personId) {
+        siblingIds.add(child.id);
+      }
+    });
   });
   
-  return siblings;
+  return hierarchy.persons.filter(person => siblingIds.has(person.id));
 }
 
 /**


### PR DESCRIPTION
Use a Set to deduplicate siblings in `getSiblings` to prevent shared siblings from appearing multiple times.

---

[Open in Web](https://www.cursor.com/agents?id=bc-07491e71-26f2-4f1a-98c8-8e8482ee7918) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-07491e71-26f2-4f1a-98c8-8e8482ee7918)