### PR TITLE
Fix Supabase query count handling

### DIFF
--- a/src/components/SignedInHome.tsx
+++ b/src/components/SignedInHome.tsx
@@ -78,10 +78,10 @@ const SignedInHome = () => {
         supabase.from('media_items').select('id', { count: 'exact' }).eq('user_id', user!.id)
       ]);
 
-      // Fetch organizations count (both owned and member organizations)
+      // Fetch organizations data (both owned and member organizations)
       const [ownedOrgsData, memberOrgsData] = await Promise.all([
-        supabase.from('organizations').select('id', { count: 'exact' }).eq('owner_id', user!.id),
-        supabase.from('organization_memberships').select('organization_id', { count: 'exact' }).eq('user_id', user!.id)
+        supabase.from('organizations').select('id').eq('owner_id', user!.id),
+        supabase.from('organization_memberships').select('organization_id').eq('user_id', user!.id)
       ]);
 
       // Get unique organization count (owned + member organizations, avoiding duplicates)


### PR DESCRIPTION
Remove `{ count: 'exact' }` from organization queries to correctly fetch and deduplicate user organizations.

---

[Open in Web](https://www.cursor.com/agents?id=bc-5bce0c37-7bb2-4c1a-a2bd-400b7bde9438) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-5bce0c37-7bb2-4c1a-a2bd-400b7bde9438)