### PR TITLE
Fix Supabase query UUID quoting in .or().in()

### DIFF
--- a/src/pages/People.tsx
+++ b/src/pages/People.tsx
@@ -132,7 +132,7 @@ export default function People() {
         const { data: connectionsData, error: connectionsError } = await supabase
           .from('connections')
           .select('from_person_id, to_person_id')
-          .or(`from_person_id.in.(${personIds.map(id => `"${id}"`).join(',')}),to_person_id.in.(${personIds.map(id => `"${id}"`).join(',')})`);
+          .or(`from_person_id.in.(${personIds.join(',')}),to_person_id.in.(${personIds.join(',')})`);
 
         if (connectionsError) throw connectionsError;
         allConnections = connectionsData || [];


### PR DESCRIPTION
Fix Supabase query for connection counts by removing incorrect UUID quoting in `.in()` clauses.

The previous implementation manually quoted UUIDs, which is not expected by Supabase's PostgREST syntax for `.in()` filters, leading to query failures or no results.

---

[Open in Web](https://www.cursor.com/agents?id=bc-1f0f58d8-f098-4625-b48c-ea9b38f4acc5) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-1f0f58d8-f098-4625-b48c-ea9b38f4acc5)