### PR TITLE
Fix people page query for non-existent view

### DIFF
--- a/src/pages/People.tsx
+++ b/src/pages/People.tsx
@@ -89,6 +89,7 @@ export default function People() {
       setLoading(true);
 
       // Use the persons_with_trees view to get persons and their tree counts in one query
+      // The view uses SECURITY INVOKER, so RLS policies automatically filter by user_id
       const { data: personsData, error: personsError } = await supabase
         .from('persons_with_trees')
         .select(`
@@ -111,7 +112,6 @@ export default function People() {
           created_at,
           family_trees
         `)
-        .eq('user_id', user.id)
         .order('is_self', { ascending: false })
         .order('name');
 


### PR DESCRIPTION
Remove redundant `user_id` filter from `persons_with_trees` query to leverage RLS.

The `persons_with_trees` view is configured with `SECURITY INVOKER`, meaning it automatically respects Row Level Security (RLS) policies from the underlying `persons` table. The explicit `user_id` filter was redundant and potentially conflicting, as RLS already ensures users only see their own data.

---

[Open in Web](https://www.cursor.com/agents?id=bc-3bcd5817-e385-43a2-b50d-275b4af6ffc4) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-3bcd5817-e385-43a2-b50d-275b4af6ffc4)