### PR TITLE
Fix organization onboarding string mismatch

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -146,6 +146,41 @@ const Dashboard = () => {
     }
   };
 
+  const checkOrganizationSetup = async (organizationId: string) => {
+    try {
+      const { data: org, error } = await supabase
+        .from('organizations')
+        .select('id, type, description')
+        .eq('id', organizationId)
+        .single();
+
+      if (error) throw error;
+
+      // Check if organization needs onboarding
+      if (org.type === 'fertility_clinic' && 
+          org.description === 'Organization created by user') {
+        navigate(`/organizations/${organizationId}/onboarding`);
+      } else {
+        navigate(`/organizations/${organizationId}`);
+      }
+    } catch (error) {
+      console.error('Error checking organization setup:', error);
+      // If there's an error, still navigate to the organization dashboard
+      navigate(`/organizations/${organizationId}`);
+    }
+  };
+
+  // Check if user has an organization account that needs onboarding
+  useEffect(() => {
+    if (profile && organizations.length > 0) {
+      // Check if user owns any organization that might need onboarding
+      const ownedOrg = organizations.find(org => org.role === 'owner');
+      if (ownedOrg) {
+        checkOrganizationSetup(ownedOrg.id);
+      }
+    }
+  }, [profile, organizations]);
+
   if (loading || isLoadingData) {
     return (
       <div className="flex items-center justify-center h-full">


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Implement missing organization onboarding check and correct description string to enable proper redirection.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The bug report indicated a string mismatch in an existing check, but investigation revealed the entire organization onboarding check logic was missing from `Dashboard.tsx`. This PR adds the `checkOrganizationSetup` function and its `useEffect` hook, using the correct 'Organization created by user' string that matches the database migration, thereby enabling the intended redirection to the onboarding flow.

---

[Open in Web](https://www.cursor.com/agents?id=bc-cd85d10d-1e18-48f5-9f3c-8a7d63eebd8a) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-cd85d10d-1e18-48f5-9f3c-8a7d63eebd8a)