### PR TITLE
Fix dashboard redirect bug and improve hook logic

### DIFF
--- a/src/components/navigation/ContextSwitcher.tsx
+++ b/src/components/navigation/ContextSwitcher.tsx
@@ -106,8 +106,12 @@ const ContextSwitcher = ({ className }: ContextSwitcherProps) => {
     setCurrentContext(value);
     
     if (value === "personal") {
+      // Mark that user explicitly navigated to personal dashboard
+      sessionStorage.setItem('explicit-personal-dashboard', 'true');
       navigate("/dashboard");
     } else {
+      // Clear any explicit personal navigation flag when switching to organization
+      sessionStorage.removeItem('explicit-personal-dashboard');
       // Navigate to organization dashboard
       navigate(`/organizations/${value}`);
     }

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -33,6 +33,8 @@ const Auth = () => {
   useEffect(() => {
     if (user) {
       console.log('User authenticated, redirecting to dashboard');
+      // Mark as explicit navigation since user just authenticated
+      sessionStorage.setItem('explicit-personal-dashboard', 'true');
       navigate("/dashboard");
     }
   }, [user, navigate]);

--- a/src/pages/InvitationPage.tsx
+++ b/src/pages/InvitationPage.tsx
@@ -121,6 +121,8 @@ const InvitationPage = () => {
         if (action === 'accept' && data.organization?.id) {
           navigate(`/organizations/${data.organization.id}`);
         } else {
+          // Mark as explicit navigation when declining invitation
+          sessionStorage.setItem('explicit-personal-dashboard', 'true');
           navigate('/dashboard');
         }
       } else {


### PR DESCRIPTION
Refactor Dashboard redirect logic to allow explicit access to the personal dashboard and prevent unwanted redirects.

The previous `useEffect` in `Dashboard.tsx` automatically redirected organization owners, making the personal dashboard inaccessible and causing potential redirect loops. This PR introduces a session flag to differentiate between intentional navigation to the personal dashboard and automatic redirects. It also addresses stale closures by wrapping functions with `useCallback` and prevents repeated redirects by using a ref to ensure the redirect logic runs only on initial load.

---

[Open in Web](https://www.cursor.com/agents?id=bc-120a7503-75d7-4ac0-808e-b441bc9d151c) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-120a7503-75d7-4ac0-808e-b441bc9d151c)