### PR TITLE
Fix dashboard redirect flag clearing logic

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -184,16 +184,13 @@ const Dashboard = () => {
       // and user has owned organizations
       if (ownedOrganizations.length > 0) {
         hasRedirectedRef.current = true;
+        // Clear the session flag only when we actually redirect
+        sessionStorage.removeItem('explicit-personal-dashboard');
         // For now, redirect to the first owned organization
         // In the future, this could be enhanced to remember the last used organization
         const primaryOrg = ownedOrganizations[0];
         checkOrganizationSetup(primaryOrg.id);
       }
-    }
-    
-    // Clear the session flag after check
-    if (hasExplicitlyNavigatedToPersonal) {
-      sessionStorage.removeItem('explicit-personal-dashboard');
     }
   }, [profile, organizations, checkOrganizationSetup]);
 


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Move `explicit-personal-dashboard` flag clearing to prevent unintended auto-redirection to an organization dashboard.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `explicit-personal-dashboard` session storage flag was cleared on every re-render, even if no redirect occurred. This premature clearing, combined with `hasRedirectedRef.current` not being set, created a race condition, leading to unexpected auto-redirection for users who explicitly navigated to their personal dashboard. The flag is now only cleared when an actual redirect takes place.

---

[Open in Web](https://www.cursor.com/agents?id=bc-804200fb-f039-4fc3-9963-7d7eeb75ad84) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-804200fb-f039-4fc3-9963-7d7eeb75ad84)