### PR TITLE
Fix persistent dashboard redirect flag

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -176,6 +176,12 @@ const Dashboard = () => {
     // Only redirect on initial load and if user hasn't explicitly navigated to personal dashboard
     const hasExplicitlyNavigatedToPersonal = sessionStorage.getItem('explicit-personal-dashboard');
     
+    // Clear the session flag after checking it, regardless of whether we redirect
+    // This ensures the flag only prevents auto-redirect for a single load cycle
+    if (hasExplicitlyNavigatedToPersonal) {
+      sessionStorage.removeItem('explicit-personal-dashboard');
+    }
+    
     if (profile && organizations.length > 0 && !hasExplicitlyNavigatedToPersonal && !hasRedirectedRef.current) {
       // Check if user owns any organization that might need onboarding
       const ownedOrganizations = organizations.filter(org => org.role === 'owner');
@@ -184,8 +190,6 @@ const Dashboard = () => {
       // and user has owned organizations
       if (ownedOrganizations.length > 0) {
         hasRedirectedRef.current = true;
-        // Clear the session flag only when we actually redirect
-        sessionStorage.removeItem('explicit-personal-dashboard');
         // For now, redirect to the first owned organization
         // In the future, this could be enhanced to remember the last used organization
         const primaryOrg = ownedOrganizations[0];


### PR DESCRIPTION
Move `explicit-personal-dashboard` session flag clearing logic to ensure it clears after one load cycle.

The flag clearing logic was previously inside a conditional block that only executed when the flag was *not* set, leading to a logical contradiction. This caused the flag to persist indefinitely, permanently blocking future auto-redirections if no redirect occurred on the initial load after setting the flag.

---

[Open in Web](https://www.cursor.com/agents?id=bc-1741c1b8-8d6d-4b3f-ab2c-fd6206e1f2f3) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-1741c1b8-8d6d-4b3f-ab2c-fd6206e1f2f3)