### PR TITLE
Fix dashboard redirect bug and improve hook logic

### DIFF
--- a/src/components/organizations/OrganizationDashboard.tsx
+++ b/src/components/organizations/OrganizationDashboard.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { useParams, Link } from "react-router-dom";
+import { useParams, Link, useNavigate } from "react-router-dom";
 import { supabase } from "@/integrations/supabase/client";
 import { useAuth } from "@/components/auth/AuthContext";
 import { Button } from "@/components/ui/button";
@@ -18,7 +18,8 @@ import {
   Shield,
   Calendar,
   MapPin,
-  Globe
+  Globe,
+  Home
 } from "lucide-react";
 import CreateOrganizationDialog from "./CreateOrganizationDialog";
 import { OrganizationInviteDialog } from "./OrganizationInviteDialog";
@@ -53,6 +54,7 @@ export function OrganizationDashboard() {
   const { id } = useParams<{ id: string }>();
   const { user } = useAuth();
   const { toast } = useToast();
+  const navigate = useNavigate();
   
   const [organization, setOrganization] = useState<Organization | null>(null);
   const [membership, setMembership] = useState<OrganizationMembership | null>(null);
@@ -173,6 +175,14 @@ export function OrganizationDashboard() {
         </div>
 
         <div className="flex gap-2">
+          <Button
+            variant="outline"
+            onClick={() => navigate('/dashboard', { state: { viewPersonalDashboard: true } })}
+            className="flex items-center gap-2"
+          >
+            <Home className="h-4 w-4" />
+            Personal Dashboard
+          </Button>
           {canManage && (
             <>
               <Button

--- a/src/pages/Organizations.tsx
+++ b/src/pages/Organizations.tsx
@@ -16,7 +16,8 @@ import {
   Crown,
   MoreHorizontal,
   UserPlus,
-  Eye
+  Eye,
+  Home
 } from "lucide-react";
 import {
   DropdownMenu,
@@ -157,7 +158,17 @@ const Organizations = () => {
             Manage your family groups, clinics, and other organizations
           </p>
         </div>
-        <CreateOrganizationDialog onOrganizationCreated={fetchOrganizations} />
+        <div className="flex gap-2">
+          <Button
+            variant="outline"
+            onClick={() => navigate('/dashboard', { state: { viewPersonalDashboard: true } })}
+            className="flex items-center gap-2"
+          >
+            <Home className="h-4 w-4" />
+            Personal Dashboard
+          </Button>
+          <CreateOrganizationDialog onOrganizationCreated={fetchOrganizations} />
+        </div>
       </div>
 
       {organizations.length === 0 ? (


### PR DESCRIPTION
Allow organization owners to access their personal dashboard and prevent redirect loops.

The Dashboard page's `useEffect` previously forced organization owners into an organization context, making their personal dashboard inaccessible and leading to potential redirect loops. This PR introduces context awareness to allow explicit personal dashboard access, prevents repeated redirects, and corrects `useEffect` dependencies.

---

[Open in Web](https://www.cursor.com/agents?id=bc-d1b5b426-68e6-4700-9552-e88d3bb1577c) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-d1b5b426-68e6-4700-9552-e88d3bb1577c)