### PR TITLE
Fix dashboard session flag clearing logic

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -176,12 +176,6 @@ const Dashboard = () => {
     // Only redirect on initial load and if user hasn't explicitly navigated to personal dashboard
     const hasExplicitlyNavigatedToPersonal = sessionStorage.getItem('explicit-personal-dashboard');
     
-    // Clear the session flag after checking it, regardless of whether we redirect
-    // This ensures the flag only prevents auto-redirect for a single load cycle
-    if (hasExplicitlyNavigatedToPersonal) {
-      sessionStorage.removeItem('explicit-personal-dashboard');
-    }
-    
     if (profile && organizations.length > 0 && !hasExplicitlyNavigatedToPersonal && !hasRedirectedRef.current) {
       // Check if user owns any organization that might need onboarding
       const ownedOrganizations = organizations.filter(org => org.role === 'owner');
@@ -189,6 +183,10 @@ const Dashboard = () => {
       // Only auto-redirect if this is the first load (not a subsequent data refresh)
       // and user has owned organizations
       if (ownedOrganizations.length > 0) {
+        // Clear the session flag only when an actual redirect occurs
+        // This ensures the flag only prevents auto-redirect for a single load cycle
+        sessionStorage.removeItem('explicit-personal-dashboard');
+        
         hasRedirectedRef.current = true;
         // For now, redirect to the first owned organization
         // In the future, this could be enhanced to remember the last used organization


### PR DESCRIPTION
Clear `explicit-personal-dashboard` session flag only when an actual redirect to an organization setup occurs.

---

[Open in Web](https://www.cursor.com/agents?id=bc-fd6958c7-2c5c-47fb-8c95-51ccb354551a) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-fd6958c7-2c5c-47fb-8c95-51ccb354551a)