### PR TITLE
Fix dashboard session flag clearing logic

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -176,12 +176,6 @@ const Dashboard = () => {
     // Only redirect on initial load and if user hasn't explicitly navigated to personal dashboard
     const hasExplicitlyNavigatedToPersonal = sessionStorage.getItem('explicit-personal-dashboard');
     
-    // Clear the session flag regardless of whether redirect occurs
-    // This ensures the flag only prevents auto-redirect for a single load cycle
-    if (hasExplicitlyNavigatedToPersonal) {
-      sessionStorage.removeItem('explicit-personal-dashboard');
-    }
-    
     if (profile && organizations.length > 0 && !hasExplicitlyNavigatedToPersonal && !hasRedirectedRef.current) {
       // Check if user owns any organization that might need onboarding
       const ownedOrganizations = organizations.filter(org => org.role === 'owner');
@@ -190,6 +184,9 @@ const Dashboard = () => {
       // and user has owned organizations
       if (ownedOrganizations.length > 0) {
         hasRedirectedRef.current = true;
+        // Clear the session flag only when an actual redirect occurs
+        // This ensures the flag only prevents auto-redirect for a single load cycle
+        sessionStorage.removeItem('explicit-personal-dashboard');
         // For now, redirect to the first owned organization
         // In the future, this could be enhanced to remember the last used organization
         const primaryOrg = ownedOrganizations[0];


### PR DESCRIPTION
Move `explicit-personal-dashboard` session storage flag clearing to only occur upon actual redirect to prevent unintended auto-redirections.

Previously, the `explicit-personal-dashboard` session storage flag was cleared unconditionally at the beginning of the `useEffect` hook. This caused the flag to be cleared even when redirect conditions were not met (e.g., data not loaded or no owned organizations), potentially leading to unintended auto-redirections on subsequent effect runs. This PR ensures the flag is only cleared when an actual redirect to an organization setup occurs.

---

[Open in Web](https://www.cursor.com/agents?id=bc-cbef1481-dc81-428e-8a72-05fddcacb8ee) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-cbef1481-dc81-428e-8a72-05fddcacb8ee)