### PR TITLE
Deduplicate parent child relationships

### DIFF
--- a/src/utils/familyChartAdapter.ts
+++ b/src/utils/familyChartAdapter.ts
@@ -67,10 +67,14 @@ export function transformToFamilyChartData(
       case 'parent':
         // from_person is parent of to_person
         if (!toNode.rels.parents) toNode.rels.parents = [];
-        toNode.rels.parents.push(fromNode.id);
+        if (!toNode.rels.parents.includes(fromNode.id)) {
+          toNode.rels.parents.push(fromNode.id);
+        }
         
         if (!fromNode.rels.children) fromNode.rels.children = [];
-        fromNode.rels.children.push(toNode.id);
+        if (!fromNode.rels.children.includes(toNode.id)) {
+          fromNode.rels.children.push(toNode.id);
+        }
         
         console.log('familyChartAdapter: Set parent relationship:', fromNode.data.name, '->', toNode.data.name);
         break;
@@ -78,10 +82,14 @@ export function transformToFamilyChartData(
       case 'child':
         // from_person is child of to_person
         if (!fromNode.rels.parents) fromNode.rels.parents = [];
-        fromNode.rels.parents.push(toNode.id);
+        if (!fromNode.rels.parents.includes(toNode.id)) {
+          fromNode.rels.parents.push(toNode.id);
+        }
         
         if (!toNode.rels.children) toNode.rels.children = [];
-        toNode.rels.children.push(fromNode.id);
+        if (!toNode.rels.children.includes(fromNode.id)) {
+          toNode.rels.children.push(fromNode.id);
+        }
         
         console.log('familyChartAdapter: Set parent relationship:', toNode.data.name, '->', fromNode.data.name);
         break;


### PR DESCRIPTION
Add duplicate checks for parent/child relationships to prevent duplicates and ensure consistent handling.

---

[Open in Web](https://www.cursor.com/agents?id=bc-7edf18bd-cbf0-4130-b4f0-c0f92c579df0) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-7edf18bd-cbf0-4130-b4f0-c0f92c579df0)