### PR TITLE
Fix family chart parent relationship logic

### DIFF
--- a/src/utils/familyChartAdapter.ts
+++ b/src/utils/familyChartAdapter.ts
@@ -126,6 +126,93 @@ export function transformToFamilyChartData(
 }
 
 /**
+ * Alternative transformation that creates a simpler, flatter structure
+ * This is more commonly used by D3-based family tree libraries
+ */
+export function transformToSimpleFamilyData(
+  persons: Person[],
+  connections: Connection[]
+): any[] {
+  console.log('familyChartAdapter: Creating simple family data structure');
+  
+  // Create nodes with basic properties
+  const nodes = persons.map(person => {
+    const node: any = {
+      id: person.id,
+      name: person.name || 'Unknown',
+      gender: person.gender === 'male' ? 'male' : person.gender === 'female' ? 'female' : undefined,
+      img: person.profile_photo_url || undefined,
+      // Store the original person data
+      _data: person
+    };
+    
+    // Find parent connections
+    // Case 1: relationship_type is 'parent' and from_person is the parent of to_person (current person)
+    // Case 2: relationship_type is 'child' and to_person is the parent of from_person (current person)
+    const parentConnections = connections.filter(conn => {
+      if (conn.relationship_type === 'parent' && conn.to_person_id === person.id) {
+        // from_person is parent of current person
+        return true;
+      }
+      if (conn.relationship_type === 'child' && conn.from_person_id === person.id) {
+        // to_person is parent of current person
+        return true;
+      }
+      return false;
+    });
+    
+    // Find spouse connections
+    const spouseConnections = connections.filter(
+      conn => (conn.from_person_id === person.id || conn.to_person_id === person.id) &&
+      (conn.relationship_type === 'spouse' || conn.relationship_type === 'partner')
+    );
+    
+    // Set parent IDs
+    parentConnections.forEach(conn => {
+      let parentId: string;
+      
+      // Determine which person is the parent based on relationship type
+      if (conn.relationship_type === 'parent' && conn.to_person_id === person.id) {
+        // from_person is the parent
+        parentId = conn.from_person_id;
+      } else if (conn.relationship_type === 'child' && conn.from_person_id === person.id) {
+        // to_person is the parent
+        parentId = conn.to_person_id;
+      } else {
+        return; // Skip if we can't determine the parent
+      }
+      
+      const parent = persons.find(p => p.id === parentId);
+      if (parent) {
+        if (parent.gender === 'male') {
+          node.fid = parent.id; // father id
+        } else if (parent.gender === 'female') {
+          node.mid = parent.id; // mother id
+        }
+      }
+    });
+    
+    // Set partner IDs (pids)
+    node.pids = [];
+    spouseConnections.forEach(conn => {
+      const partnerId = conn.from_person_id === person.id ? conn.to_person_id : conn.from_person_id;
+      if (!node.pids.includes(partnerId)) {
+        node.pids.push(partnerId);
+      }
+    });
+    
+    if (node.pids.length === 0) {
+      delete node.pids;
+    }
+    
+    return node;
+  });
+  
+  console.log('familyChartAdapter: Simple nodes created:', nodes);
+  return nodes;
+}
+
+/**
  * Find the root node for the family tree (typically the oldest generation or marked as self)
  */
 export function findRootNode(nodes: FamilyChartNode[], persons: Person[]): string | undefined {

--- a/src/utils/familyChartAdapter.ts
+++ b/src/utils/familyChartAdapter.ts
@@ -27,25 +27,20 @@ export function transformToFamilyChartData(
   console.log('familyChartAdapter: Starting transformation with', persons.length, 'persons and', connections.length, 'connections');
   
   // Create a map to build relationships
-  const nodeMap = new Map<string, any>();
+  const nodeMap = new Map<string, FamilyChartNode>();
   
   // Initialize all persons as nodes with the correct structure
   persons.forEach(person => {
-    const node = {
+    const node: FamilyChartNode = {
       id: person.id,
-      data: {
-        name: person.name || 'Unknown',
-        gender: person.gender === 'male' ? 'M' : person.gender === 'female' ? 'F' : undefined,
-        birthday: person.date_of_birth || undefined,
-        avatar: person.profile_photo_url || undefined,
-        // Add additional data for reference
-        person: person
-      },
-      rels: {
-        spouses: [],
-        children: [],
-        parents: []
-      }
+      name: person.name || 'Unknown',
+      gender: person.gender === 'male' ? 'M' : person.gender === 'female' ? 'F' : undefined,
+      birthday: person.date_of_birth || undefined,
+      avatar: person.profile_photo_url || undefined,
+      pids: [], // Partner IDs
+      // mid and fid will be set when processing parent relationships
+      // Add additional data for reference
+      person: person
     };
     
     nodeMap.set(person.id, node);
@@ -66,39 +61,55 @@ export function transformToFamilyChartData(
     switch (connection.relationship_type) {
       case 'parent':
         // from_person is parent of to_person
-        if (!toNode.rels.parents) toNode.rels.parents = [];
-        toNode.rels.parents.push(fromNode.id);
+        // Determine if parent is mother or father based on gender
+        if (fromNode.gender === 'F') {
+          toNode.mid = fromNode.id;
+        } else if (fromNode.gender === 'M') {
+          toNode.fid = fromNode.id;
+        } else {
+          // If gender is unknown, check if mid is already set
+          if (!toNode.mid) {
+            toNode.mid = fromNode.id;
+          } else if (!toNode.fid) {
+            toNode.fid = fromNode.id;
+          }
+        }
         
-        if (!fromNode.rels.children) fromNode.rels.children = [];
-        fromNode.rels.children.push(toNode.id);
-        
-        console.log('familyChartAdapter: Set parent relationship:', fromNode.data.name, '->', toNode.data.name);
+        console.log('familyChartAdapter: Set parent relationship:', fromNode.name, '->', toNode.name);
         break;
         
       case 'child':
         // from_person is child of to_person
-        if (!fromNode.rels.parents) fromNode.rels.parents = [];
-        fromNode.rels.parents.push(toNode.id);
+        // Determine if parent is mother or father based on gender
+        if (toNode.gender === 'F') {
+          fromNode.mid = toNode.id;
+        } else if (toNode.gender === 'M') {
+          fromNode.fid = toNode.id;
+        } else {
+          // If gender is unknown, check if mid is already set
+          if (!fromNode.mid) {
+            fromNode.mid = toNode.id;
+          } else if (!fromNode.fid) {
+            fromNode.fid = toNode.id;
+          }
+        }
         
-        if (!toNode.rels.children) toNode.rels.children = [];
-        toNode.rels.children.push(fromNode.id);
-        
-        console.log('familyChartAdapter: Set parent relationship:', toNode.data.name, '->', fromNode.data.name);
+        console.log('familyChartAdapter: Set parent relationship:', toNode.name, '->', fromNode.name);
         break;
         
       case 'spouse':
       case 'partner':
         // Add partners/spouses
-        if (!fromNode.rels.spouses) fromNode.rels.spouses = [];
-        if (!toNode.rels.spouses) toNode.rels.spouses = [];
+        if (!fromNode.pids) fromNode.pids = [];
+        if (!toNode.pids) toNode.pids = [];
         
-        if (!fromNode.rels.spouses.includes(toNode.id)) {
-          fromNode.rels.spouses.push(toNode.id);
+        if (!fromNode.pids.includes(toNode.id)) {
+          fromNode.pids.push(toNode.id);
         }
-        if (!toNode.rels.spouses.includes(fromNode.id)) {
-          toNode.rels.spouses.push(fromNode.id);
+        if (!toNode.pids.includes(fromNode.id)) {
+          toNode.pids.push(fromNode.id);
         }
-        console.log('familyChartAdapter: Set partner relationship:', fromNode.data.name, '<->', toNode.data.name);
+        console.log('familyChartAdapter: Set partner relationship:', fromNode.name, '<->', toNode.name);
         break;
         
       // Note: Other relationship types like 'sibling' are typically derived 
@@ -117,7 +128,7 @@ export function transformToFamilyChartData(
 /**
  * Find the root node for the family tree (typically the oldest generation or marked as self)
  */
-export function findRootNode(nodes: any[], persons: Person[]): string | undefined {
+export function findRootNode(nodes: FamilyChartNode[], persons: Person[]): string | undefined {
   // First, try to find a person marked as self
   const selfPerson = persons.find(p => p.is_self === true);
   if (selfPerson) {
@@ -125,7 +136,8 @@ export function findRootNode(nodes: any[], persons: Person[]): string | undefine
   }
   
   // If no self person, find someone without parents (root of tree)
-  const rootNode = nodes.find(node => !node.rels.parents || node.rels.parents.length === 0);
+  // In family-chart format, a node without parents has no mid (mother) and no fid (father)
+  const rootNode = nodes.find(node => !node.mid && !node.fid);
   if (rootNode) {
     return rootNode.id;
   }


### PR DESCRIPTION
Align family chart data structure and root node detection with `family-chart` library's `mid`/`fid` expectations.

The previous implementation used a `rels.parents` array, which was inconsistent with the `family-chart` library's expectation of `mid` and `fid` properties for parent relationships, leading to incorrect root node identification. This PR updates the node transformation and `findRootNode` to use `mid`, `fid`, and `pids` properties directly on the nodes.

---

[Open in Web](https://www.cursor.com/agents?id=bc-df7670d5-623a-412d-bdbb-7b1088b7724f) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-df7670d5-623a-412d-bdbb-7b1088b7724f)