### PR TITLE
Fix sessionStorage flag clearing in dashboard

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -184,9 +184,9 @@ const Dashboard = () => {
       // and user has owned organizations
       if (ownedOrganizations.length > 0) {
         hasRedirectedRef.current = true;
-        // Clear the session flag only when an actual redirect occurs
-        // This ensures the flag only prevents auto-redirect for a single load cycle
-        sessionStorage.removeItem('explicit-personal-dashboard');
+        // Do not clear the session flag here - it should persist to prevent
+        // unwanted auto-redirects on subsequent data refreshes
+        // The flag will be cleared when user navigates away via ContextSwitcher
         // For now, redirect to the first owned organization
         // In the future, this could be enhanced to remember the last used organization
         const primaryOrg = ownedOrganizations[0];


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Stop prematurely clearing `explicit-personal-dashboard` session flag to prevent unwanted auto-redirects.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `explicit-personal-dashboard` flag was prematurely cleared in `Dashboard.tsx`'s `useEffect`, even when no auto-redirection occurred. This led to unwanted auto-redirects on subsequent data refreshes, overriding the user's choice to remain on the personal dashboard. The flag should persist until the user explicitly navigates away.

---

[Open in Web](https://www.cursor.com/agents?id=bc-6278542f-6889-42a5-935e-6e10bb572fa1) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-6278542f-6889-42a5-935e-6e10bb572fa1)