### PR TITLE
Fix family data transformation bugs

### DIFF
--- a/src/utils/familyChartAdapter.ts
+++ b/src/utils/familyChartAdapter.ts
@@ -185,9 +185,22 @@ export function transformToSimpleFamilyData(
       const parent = persons.find(p => p.id === parentId);
       if (parent) {
         if (parent.gender === 'male') {
-          node.fid = parent.id; // father id
+          // Only set if not already set (to prevent overwriting)
+          if (!node.fid) {
+            node.fid = parent.id; // father id
+          }
         } else if (parent.gender === 'female') {
-          node.mid = parent.id; // mother id
+          // Only set if not already set (to prevent overwriting)
+          if (!node.mid) {
+            node.mid = parent.id; // mother id
+          }
+        } else {
+          // If gender is unknown, use fallback logic similar to transformToFamilyChartData
+          if (!node.mid) {
+            node.mid = parent.id;
+          } else if (!node.fid) {
+            node.fid = parent.id;
+          }
         }
       }
     });
@@ -201,9 +214,8 @@ export function transformToSimpleFamilyData(
       }
     });
     
-    if (node.pids.length === 0) {
-      delete node.pids;
-    }
+    // Keep empty pids arrays to maintain consistency with transformToFamilyChartData
+    // (removed the deletion of empty pids)
     
     return node;
   });


### PR DESCRIPTION
Fix `transformToSimpleFamilyData` to correctly assign parent IDs for unknown genders, prevent overwrites for multiple parents, and retain empty `pids` arrays.

---

[Open in Web](https://www.cursor.com/agents?id=bc-681da2d6-1efa-45d1-9379-3a8e67952f4f) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-681da2d6-1efa-45d1-9379-3a8e67952f4f)