### PR TITLE
Fix parent-child relationship processing in family chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ supabase/.temp/postgres-version
 supabase/.temp/pooler-url
 supabase/.temp/gotrue-version
 supabase/.temp/cli-latest
+core

--- a/src/test/utils/familyChartAdapter.test.ts
+++ b/src/test/utils/familyChartAdapter.test.ts
@@ -231,5 +231,69 @@ describe('familyChartAdapter', () => {
       expect(childNode?._allParents).toEqual(['parent1']);
       expect(childNode?.fid).toBe('parent1');
     });
+
+    it('should not assign same unknown gender parent to both fid and mid slots', () => {
+      const persons: Person[] = [
+        { id: 'child1', name: 'Child 1', gender: 'female' },
+        { id: 'parent1', name: 'Parent 1', gender: undefined } // Unknown gender
+      ];
+
+      const connections: Connection[] = [
+        { 
+          id: 'conn1',
+          from_person_id: 'parent1',
+          to_person_id: 'child1',
+          relationship_type: 'parent'
+        },
+        { 
+          id: 'conn2',
+          from_person_id: 'parent1',
+          to_person_id: 'child1',
+          relationship_type: 'parent'
+        }
+      ];
+
+      const result = transformToFamilyChartData(persons, connections);
+      const childNode = result.nodes.find(n => n.id === 'child1');
+
+      // Parent should only be assigned to fid, not both fid and mid
+      expect(childNode?.fid).toBe('parent1');
+      expect(childNode?.mid).toBeUndefined();
+      expect(childNode?._allParents).toEqual(['parent1']);
+      // Duplicate relationship should be skipped entirely
+      expect(childNode?._unknownGenderParents).toBeUndefined();
+    });
+
+    it('should handle duplicate child relationships with unknown gender parent correctly', () => {
+      const persons: Person[] = [
+        { id: 'child1', name: 'Child 1', gender: 'male' },
+        { id: 'parent1', name: 'Parent 1', gender: undefined } // Unknown gender
+      ];
+
+      const connections: Connection[] = [
+        { 
+          id: 'conn1',
+          from_person_id: 'child1',
+          to_person_id: 'parent1',
+          relationship_type: 'child'
+        },
+        { 
+          id: 'conn2',
+          from_person_id: 'child1',
+          to_person_id: 'parent1',
+          relationship_type: 'child'
+        }
+      ];
+
+      const result = transformToFamilyChartData(persons, connections);
+      const childNode = result.nodes.find(n => n.id === 'child1');
+
+      // Parent should only be assigned to fid, not both fid and mid
+      expect(childNode?.fid).toBe('parent1');
+      expect(childNode?.mid).toBeUndefined();
+      expect(childNode?._allParents).toEqual(['parent1']);
+      // Duplicate relationship should be skipped entirely
+      expect(childNode?._unknownGenderParents).toBeUndefined();
+    });
   });
 });

--- a/src/test/utils/familyChartAdapter.test.ts
+++ b/src/test/utils/familyChartAdapter.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, vi } from 'vitest';
+import { transformToFamilyChartData } from '@/utils/familyChartAdapter';
+import { Person } from '@/types/person';
+import { Connection } from '@/types/connection';
+
+describe('familyChartAdapter', () => {
+  describe('transformToFamilyChartData', () => {
+    it('should handle parents with unknown gender by assigning them to available slots', () => {
+      const persons: Person[] = [
+        { id: 'child1', name: 'Child 1', gender: 'male' },
+        { id: 'parent1', name: 'Parent 1', gender: undefined }, // Unknown gender
+        { id: 'parent2', name: 'Parent 2', gender: 'female' }
+      ];
+
+      const connections: Connection[] = [
+        { 
+          id: 'conn1',
+          from_person_id: 'parent1',
+          to_person_id: 'child1',
+          relationship_type: 'parent'
+        },
+        { 
+          id: 'conn2',
+          from_person_id: 'parent2',
+          to_person_id: 'child1',
+          relationship_type: 'parent'
+        }
+      ];
+
+      const result = transformToFamilyChartData(persons, connections);
+      const childNode = result.nodes.find(n => n.id === 'child1');
+
+      // Parent with unknown gender should be assigned to the available fid slot
+      expect(childNode?.fid).toBe('parent1');
+      expect(childNode?.mid).toBe('parent2');
+      expect(childNode?._allParents).toEqual(['parent1', 'parent2']);
+    });
+
+    it('should handle multiple parents of the same gender', () => {
+      const persons: Person[] = [
+        { id: 'child1', name: 'Child 1', gender: 'female' },
+        { id: 'father1', name: 'Father 1', gender: 'male' },
+        { id: 'father2', name: 'Father 2', gender: 'male' },
+        { id: 'mother1', name: 'Mother 1', gender: 'female' }
+      ];
+
+      const connections: Connection[] = [
+        { 
+          id: 'conn1',
+          from_person_id: 'father1',
+          to_person_id: 'child1',
+          relationship_type: 'parent'
+        },
+        { 
+          id: 'conn2',
+          from_person_id: 'father2',
+          to_person_id: 'child1',
+          relationship_type: 'parent'
+        },
+        { 
+          id: 'conn3',
+          from_person_id: 'mother1',
+          to_person_id: 'child1',
+          relationship_type: 'parent'
+        }
+      ];
+
+      const result = transformToFamilyChartData(persons, connections);
+      const childNode = result.nodes.find(n => n.id === 'child1');
+
+      // First father should be in fid, second should be in _additionalFathers
+      expect(childNode?.fid).toBe('father1');
+      expect(childNode?.mid).toBe('mother1');
+      expect(childNode?._additionalFathers).toEqual(['father2']);
+      expect(childNode?._allParents).toEqual(['father1', 'father2', 'mother1']);
+    });
+
+    it('should handle all parents with unknown gender', () => {
+      const persons: Person[] = [
+        { id: 'child1', name: 'Child 1', gender: 'male' },
+        { id: 'parent1', name: 'Parent 1', gender: undefined },
+        { id: 'parent2', name: 'Parent 2', gender: null as any },
+        { id: 'parent3', name: 'Parent 3', gender: undefined }
+      ];
+
+      const connections: Connection[] = [
+        { 
+          id: 'conn1',
+          from_person_id: 'parent1',
+          to_person_id: 'child1',
+          relationship_type: 'parent'
+        },
+        { 
+          id: 'conn2',
+          from_person_id: 'parent2',
+          to_person_id: 'child1',
+          relationship_type: 'parent'
+        },
+        { 
+          id: 'conn3',
+          from_person_id: 'parent3',
+          to_person_id: 'child1',
+          relationship_type: 'parent'
+        }
+      ];
+
+      const result = transformToFamilyChartData(persons, connections);
+      const childNode = result.nodes.find(n => n.id === 'child1');
+
+      // First two unknown gender parents should fill fid and mid slots
+      expect(childNode?.fid).toBe('parent1');
+      expect(childNode?.mid).toBe('parent2');
+      // Third parent should go to _unknownGenderParents
+      expect(childNode?._unknownGenderParents).toEqual(['parent3']);
+      expect(childNode?._allParents).toEqual(['parent1', 'parent2', 'parent3']);
+    });
+
+    it('should handle child relationships with unknown gender parents', () => {
+      const persons: Person[] = [
+        { id: 'child1', name: 'Child 1', gender: 'female' },
+        { id: 'parent1', name: 'Parent 1', gender: undefined }
+      ];
+
+      const connections: Connection[] = [
+        { 
+          id: 'conn1',
+          from_person_id: 'child1',
+          to_person_id: 'parent1',
+          relationship_type: 'child'
+        }
+      ];
+
+      const result = transformToFamilyChartData(persons, connections);
+      const childNode = result.nodes.find(n => n.id === 'child1');
+
+      // Parent with unknown gender should be assigned to fid slot (first available)
+      expect(childNode?.fid).toBe('parent1');
+      expect(childNode?.mid).toBeUndefined();
+      expect(childNode?._allParents).toEqual(['parent1']);
+    });
+
+    it('should preserve all parent connections in _allParents array', () => {
+      const persons: Person[] = [
+        { id: 'child1', name: 'Child 1', gender: 'male' },
+        { id: 'father1', name: 'Father 1', gender: 'male' },
+        { id: 'father2', name: 'Father 2', gender: 'male' },
+        { id: 'mother1', name: 'Mother 1', gender: 'female' },
+        { id: 'mother2', name: 'Mother 2', gender: 'female' },
+        { id: 'parent1', name: 'Parent 1', gender: undefined }
+      ];
+
+      const connections: Connection[] = [
+        { 
+          id: 'conn1',
+          from_person_id: 'father1',
+          to_person_id: 'child1',
+          relationship_type: 'parent'
+        },
+        { 
+          id: 'conn2',
+          from_person_id: 'father2',
+          to_person_id: 'child1',
+          relationship_type: 'parent'
+        },
+        { 
+          id: 'conn3',
+          from_person_id: 'mother1',
+          to_person_id: 'child1',
+          relationship_type: 'parent'
+        },
+        { 
+          id: 'conn4',
+          from_person_id: 'mother2',
+          to_person_id: 'child1',
+          relationship_type: 'parent'
+        },
+        { 
+          id: 'conn5',
+          from_person_id: 'parent1',
+          to_person_id: 'child1',
+          relationship_type: 'parent'
+        }
+      ];
+
+      const result = transformToFamilyChartData(persons, connections);
+      const childNode = result.nodes.find(n => n.id === 'child1');
+
+      // All parents should be preserved in _allParents
+      expect(childNode?._allParents).toHaveLength(5);
+      expect(childNode?._allParents).toContain('father1');
+      expect(childNode?._allParents).toContain('father2');
+      expect(childNode?._allParents).toContain('mother1');
+      expect(childNode?._allParents).toContain('mother2');
+      expect(childNode?._allParents).toContain('parent1');
+
+      // Standard fields should have first of each gender
+      expect(childNode?.fid).toBe('father1');
+      expect(childNode?.mid).toBe('mother1');
+
+      // Additional parents should be in custom arrays
+      expect(childNode?._additionalFathers).toEqual(['father2']);
+      expect(childNode?._additionalMothers).toEqual(['mother2']);
+      expect(childNode?._unknownGenderParents).toEqual(['parent1']);
+    });
+
+    it('should not duplicate parent IDs in _allParents array', () => {
+      const persons: Person[] = [
+        { id: 'child1', name: 'Child 1', gender: 'male' },
+        { id: 'parent1', name: 'Parent 1', gender: 'male' }
+      ];
+
+      const connections: Connection[] = [
+        { 
+          id: 'conn1',
+          from_person_id: 'parent1',
+          to_person_id: 'child1',
+          relationship_type: 'parent'
+        },
+        { 
+          id: 'conn2',
+          from_person_id: 'parent1',
+          to_person_id: 'child1',
+          relationship_type: 'parent'
+        }
+      ];
+
+      const result = transformToFamilyChartData(persons, connections);
+      const childNode = result.nodes.find(n => n.id === 'child1');
+
+      // Parent should only appear once in _allParents
+      expect(childNode?._allParents).toEqual(['parent1']);
+      expect(childNode?.fid).toBe('parent1');
+    });
+  });
+});

--- a/src/utils/familyChartAdapter.ts
+++ b/src/utils/familyChartAdapter.ts
@@ -92,7 +92,11 @@ export function transformToFamilyChartData(
           }
         } else {
           // Gender unknown - try to assign to available parent slot
-          if (!toNode.fid) {
+          // First check if this parent is already assigned
+          if (toNode.fid === fromNode.id || toNode.mid === fromNode.id) {
+            // Parent already assigned, skip
+            console.log(`familyChartAdapter: Parent ${fromNode.name} already assigned to ${toNode.name}, skipping duplicate.`);
+          } else if (!toNode.fid) {
             // No father assigned yet, use this slot
             toNode.fid = fromNode.id;
             console.warn(`familyChartAdapter: Parent ${fromNode.name} with unknown gender assigned as father for ${toNode.name}.`);
@@ -103,8 +107,10 @@ export function transformToFamilyChartData(
           } else {
             // Both slots filled, store in unknown gender parents array
             if (!toNode._unknownGenderParents) toNode._unknownGenderParents = [];
-            toNode._unknownGenderParents.push(fromNode.id);
-            console.warn(`familyChartAdapter: Parent ${fromNode.name} has unknown gender and both parent slots are filled for child ${toNode.name}. Stored in _unknownGenderParents array.`);
+            if (!toNode._unknownGenderParents.includes(fromNode.id)) {
+              toNode._unknownGenderParents.push(fromNode.id);
+              console.warn(`familyChartAdapter: Parent ${fromNode.name} has unknown gender and cannot be assigned to standard slots for child ${toNode.name}. Stored in _unknownGenderParents array.`);
+            }
           }
         }
         
@@ -140,7 +146,11 @@ export function transformToFamilyChartData(
           }
         } else {
           // Gender unknown - try to assign to available parent slot
-          if (!fromNode.fid) {
+          // First check if this parent is already assigned
+          if (fromNode.fid === toNode.id || fromNode.mid === toNode.id) {
+            // Parent already assigned, skip
+            console.log(`familyChartAdapter: Parent ${toNode.name} already assigned to ${fromNode.name}, skipping duplicate.`);
+          } else if (!fromNode.fid) {
             // No father assigned yet, use this slot
             fromNode.fid = toNode.id;
             console.warn(`familyChartAdapter: Parent ${toNode.name} with unknown gender assigned as father for ${fromNode.name}.`);
@@ -151,8 +161,10 @@ export function transformToFamilyChartData(
           } else {
             // Both slots filled, store in unknown gender parents array
             if (!fromNode._unknownGenderParents) fromNode._unknownGenderParents = [];
-            fromNode._unknownGenderParents.push(toNode.id);
-            console.warn(`familyChartAdapter: Parent ${toNode.name} has unknown gender and both parent slots are filled for child ${fromNode.name}. Stored in _unknownGenderParents array.`);
+            if (!fromNode._unknownGenderParents.includes(toNode.id)) {
+              fromNode._unknownGenderParents.push(toNode.id);
+              console.warn(`familyChartAdapter: Parent ${toNode.name} has unknown gender and cannot be assigned to standard slots for child ${fromNode.name}. Stored in _unknownGenderParents array.`);
+            }
           }
         }
         


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix incorrect parent-child relationship processing in `transformToFamilyChartData` to prevent loss of connections.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This PR addresses a regression where parent-child connections were lost in two scenarios:
1. Parents with unknown or undefined gender were not assigned to `fid`/`mid` slots, instead being relegated to a custom `_unknownGenderParents` array, making them invisible to the family chart library.
2. When a person had multiple parents of the same gender, the `fid`/`mid` fields would overwrite, retaining only the last processed parent.
The fix ensures that unknown gender parents are assigned to available `fid`/`mid` slots first, and all parent IDs are now stored in a new `_allParents` array to preserve every connection, regardless of gender or slot assignment.

---

[Open in Web](https://www.cursor.com/agents?id=bc-1cdb7805-cae5-4c54-addc-cd3028543481) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-1cdb7805-cae5-4c54-addc-cd3028543481)