### PR TITLE
Validate organization ID before navigation

### DIFF
--- a/src/components/organizations/CreateOrganizationDialog.tsx
+++ b/src/components/organizations/CreateOrganizationDialog.tsx
@@ -24,6 +24,12 @@ import {
 } from "@/components/ui/select";
 import { Plus, Loader2 } from "lucide-react";
 
+// Helper function to validate UUID format
+const isValidUUID = (uuid: string): boolean => {
+  const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+  return uuidRegex.test(uuid);
+};
+
 interface CreateOrganizationDialogProps {
   onOrganizationCreated: () => void;
 }
@@ -56,6 +62,16 @@ const CreateOrganizationDialog = ({ onOrganizationCreated }: CreateOrganizationD
 
       if (error) throw error;
 
+      // Validate that we received a valid organization ID
+      if (!data || typeof data !== 'string') {
+        throw new Error('Failed to create organization: Invalid response from server');
+      }
+
+      // Validate UUID format
+      if (!isValidUUID(data)) {
+        throw new Error('Failed to create organization: Invalid organization ID format');
+      }
+
       toast({
         title: "Organization created",
         description: `${formData.name} has been created successfully. Complete the setup to get started.`,
@@ -69,7 +85,7 @@ const CreateOrganizationDialog = ({ onOrganizationCreated }: CreateOrganizationD
       setOpen(false);
       onOrganizationCreated();
       
-      // Redirect to organization onboarding
+      // Redirect to organization onboarding with validated ID
       navigate(`/organizations/${data}/onboarding`);
     } catch (error: any) {
       toast({


### PR DESCRIPTION
Add validation for organization ID from RPC response to prevent navigation to invalid URLs.

Previously, the `CreateOrganizationDialog` component directly used the unvalidated `data` returned by the `create_organization_for_user` RPC for navigation. This could lead to navigation to invalid URLs (e.g., `/organizations/null/onboarding`) if the RPC call failed or returned an unexpected value. This PR adds checks for null/undefined, string type, and UUID format before navigation.

---

[Open in Web](https://www.cursor.com/agents?id=bc-1ad748c0-64f1-4053-8c23-02ca569d7966) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-1ad748c0-64f1-4053-8c23-02ca569d7966)