### PR TITLE
Fix organization update policy and migration script

### DIFF
--- a/supabase/migrations/20250130000000_enhance_tenant_management.sql
+++ b/supabase/migrations/20250130000000_enhance_tenant_management.sql
@@ -128,6 +128,13 @@ CREATE POLICY "Users can insert own profile" ON public.user_profiles
     FOR INSERT WITH CHECK (id = auth.uid());
 
 -- Allow organization owners to view and update their organization
+-- First drop any existing policies from previous migrations
+DROP POLICY IF EXISTS "Users can view organizations" ON public.organizations;
+DROP POLICY IF EXISTS "Users can update organizations" ON public.organizations;
+DROP POLICY IF EXISTS "Users can create organizations" ON public.organizations;
+DROP POLICY IF EXISTS "Users can delete organizations" ON public.organizations;
+
+-- Now create our new policies
 DROP POLICY IF EXISTS "Organization owners can view their organization" ON public.organizations;
 CREATE POLICY "Organization owners can view their organization" ON public.organizations
     FOR SELECT USING (owner_id = auth.uid());
@@ -135,6 +142,10 @@ CREATE POLICY "Organization owners can view their organization" ON public.organi
 DROP POLICY IF EXISTS "Organization owners can update their organization" ON public.organizations;
 CREATE POLICY "Organization owners can update their organization" ON public.organizations
     FOR UPDATE USING (owner_id = auth.uid());
+
+DROP POLICY IF EXISTS "Organization owners can delete their organization" ON public.organizations;
+CREATE POLICY "Organization owners can delete their organization" ON public.organizations
+    FOR DELETE USING (owner_id = auth.uid());
 
 -- Update existing users to have account_type if not set
 UPDATE public.user_profiles 


### PR DESCRIPTION
Refactor RLS policies for `public.organizations` to prevent conflicts and ensure owners can delete their organizations.

The original bug report was partially incorrect. While the new `SELECT` and `UPDATE` policies correctly included `DROP POLICY IF EXISTS`, the migration was missing `DROP POLICY IF EXISTS` for older, conflicting policies on `public.organizations` from a previous migration. Additionally, a `DELETE` policy for organization owners was missing from the new set, which was present in the old policies. This PR addresses these issues to ensure proper RLS behavior and prevent policy conflicts.

---

[Open in Web](https://www.cursor.com/agents?id=bc-46899b57-efe8-4830-b4fa-288865692f95) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-46899b57-efe8-4830-b4fa-288865692f95)