### PR TITLE
Debug family chart layout display issue

### DIFF
--- a/src/components/family-trees/layouts/FamilyChartLayout.tsx
+++ b/src/components/family-trees/layouts/FamilyChartLayout.tsx
@@ -166,18 +166,40 @@ export function FamilyChartLayout({
                     
                     // If createChart exists, try different API signatures
                     const signatures = [
+                        // Signature 0: Preferred pattern with nodes array and nodeBinding mapping
+                        () => createChart(containerRef.current, {
+                            nodes: familyData.nodes,
+                            rootId: rootId,
+                            nodeBinding: {
+                                field_0: 'name',
+                                img_0: 'img',
+                                field_1: 'birthday'
+                            },
+                            width: width,
+                            height: height
+                        }),
                         // Signature 1: Standard D3 pattern (container, config) with simple data
                         () => createChart(containerRef.current, {
-                            data: simpleData,
+                            nodes: simpleData,
                             rootId: simpleRootId || rootId,
+                            nodeBinding: {
+                                field_0: 'name',
+                                img_0: 'img',
+                                field_1: 'birthday'
+                            },
                             width: width,
                             height: height
                         }),
                         
                         // Signature 2: Standard D3 pattern with complex data
                         () => createChart(containerRef.current, {
-                            data: familyData.nodes,
+                            nodes: familyData.nodes,
                             rootId: rootId,
+                            nodeBinding: {
+                                field_0: 'name',
+                                img_0: 'img',
+                                field_1: 'birthday'
+                            },
                             width: width,
                             height: height
                         }),

--- a/src/utils/familyChartAdapter.ts
+++ b/src/utils/familyChartAdapter.ts
@@ -9,7 +9,7 @@ export interface FamilyChartNode {
   name: string;
   gender?: 'M' | 'F';
   birthday?: string;
-  avatar?: string;
+  img?: string;
   // Custom fields for handling complex family structures
   _additionalFathers?: string[];    // Additional fathers when multiple exist
   _additionalMothers?: string[];    // Additional mothers when multiple exist
@@ -42,7 +42,7 @@ export function transformToFamilyChartData(
       name: person.name || 'Unknown',
       gender: person.gender === 'male' ? 'M' : person.gender === 'female' ? 'F' : undefined,
       birthday: person.date_of_birth || undefined,
-      avatar: person.profile_photo_url || undefined,
+      img: person.profile_photo_url || undefined,
       pids: [], // Initialize partner IDs array
       // Store the original person data for reference
       _personData: person


### PR DESCRIPTION
Update family chart data mapping and configuration to enable rendering.

The `family-chart` library requires an `img` field for avatars and explicit `nodeBinding` to display data fields, which were previously missing or incorrect, leading to a blank canvas.

---

[Open in Web](https://www.cursor.com/agents?id=bc-beb254fe-dc08-435f-b40e-4cb0fbf615cf) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-beb254fe-dc08-435f-b40e-4cb0fbf615cf)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)